### PR TITLE
Add workaround for bug "getSkuDetails method returns response code 5 when querying more than 20 items"

### DIFF
--- a/lib/src/main/java/org/solovyev/android/checkout/GetSkuDetailsRequest.java
+++ b/lib/src/main/java/org/solovyev/android/checkout/GetSkuDetailsRequest.java
@@ -24,6 +24,7 @@ package org.solovyev.android.checkout;
 
 import android.os.Bundle;
 import android.os.RemoteException;
+
 import com.android.vending.billing.IInAppBillingService;
 
 import javax.annotation.Nonnull;
@@ -34,6 +35,12 @@ import java.util.List;
 
 final class GetSkuDetailsRequest extends Request<Skus> {
 
+    /**
+     * There are a bug on https://code.google.com/p/marketbilling/issues/detail?id=137.
+     * Currently it's still exist.
+     * So solution is breaking up the requests to query only 20 items at a time.
+     */
+    public static final int MAX_SKU_PER_REQUEST = 20;
 	@Nonnull
 	private final String product;
 
@@ -47,15 +54,27 @@ final class GetSkuDetailsRequest extends Request<Skus> {
 		Collections.sort(this.skus);
 	}
 
-	@Override
-	void start(@Nonnull IInAppBillingService service, int apiVersion, @Nonnull String packageName) throws RemoteException, RequestException {
-		final Bundle skusBundle = new Bundle();
-		skusBundle.putStringArrayList("ITEM_ID_LIST", skus);
-		final Bundle bundle = service.getSkuDetails(apiVersion, packageName, product, skusBundle);
-		if (!handleError(bundle)) {
-			onSuccess(Skus.fromBundle(bundle, product));
-		}
-	}
+    @Override
+    void start(@Nonnull IInAppBillingService service, int apiVersion, @Nonnull String packageName) throws RemoteException, RequestException {
+
+        List<ArrayList<String>> splitSkuIds = new ArrayList<>();
+        for (int i = 0; i < skus.size(); i += MAX_SKU_PER_REQUEST) {
+            splitSkuIds.add(new ArrayList<>(skus.subList(i, Math.min(skus.size(), i + MAX_SKU_PER_REQUEST - 1))));
+        }
+
+        List<Sku> skusList = new ArrayList<Sku>();
+
+        for (ArrayList<String> splitSkuId : splitSkuIds) {
+            final Bundle skusBundle = new Bundle();
+            skusBundle.putStringArrayList("ITEM_ID_LIST", splitSkuId);
+            final Bundle bundle = service.getSkuDetails(apiVersion, packageName, product, skusBundle);
+            if (handleError(bundle)) {
+                return;
+            }
+            skusList.addAll(Skus.fromBundle(bundle, product).getSkuList());
+        }
+        onSuccess(new Skus(product, skusList));
+    }
 
 	@Nullable
 	@Override

--- a/lib/src/main/java/org/solovyev/android/checkout/Skus.java
+++ b/lib/src/main/java/org/solovyev/android/checkout/Skus.java
@@ -77,6 +77,11 @@ public final class Skus {
 		return list != null ? list : Collections.<String>emptyList();
 	}
 
+	@Nonnull
+	public List<Sku> getSkuList() {
+		return list;
+	}
+
 	@Nullable
 	public Sku getSku(@Nonnull String sku) {
 		for (Sku s : list) {


### PR DESCRIPTION
There are a bug on https://code.google.com/p/marketbilling/issues/detail?id=137.
Currently it's still exist.
So solution is breaking up the requests to query only 20 items at a time.