### PR TITLE
Catch and ignore receiver not registered IllegalArgumentException

### DIFF
--- a/lib/src/main/java/org/solovyev/android/checkout/PlayStoreBroadcastReceiver.java
+++ b/lib/src/main/java/org/solovyev/android/checkout/PlayStoreBroadcastReceiver.java
@@ -48,7 +48,11 @@ class PlayStoreBroadcastReceiver extends BroadcastReceiver {
             Check.isTrue(mListeners.contains(listener), "Listener " + listener + " is not in the list");
             mListeners.remove(listener);
             if (mListeners.size() == 0) {
-                mContext.unregisterReceiver(this);
+                try {
+                    mContext.unregisterReceiver(this);
+                } catch (IllegalArgumentException e) {
+                    // Ignore
+                }
             }
         }
     }


### PR DESCRIPTION
The crash below was reported twice, both on users with an Android 6.0.1 device.

There doesn't seem to be anything I can do catch this exception in my code. There also doesn't seem to be anything else the library code and do to prevent it. 

```
Fatal Exception: java.lang.IllegalArgumentException: Receiver not registered: org.solovyev.android.checkout.bb@1f411ab
       at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:878)
       at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1279)
       at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:601)
       at org.solovyev.android.checkout.Billing.org.solovyev.android.checkout.PlayStoreBroadcastReceiver.removeListener(SourceFile:2051)
       at org.solovyev.android.checkout.Billing.setService(SourceFile:305)
       at org.solovyev.android.checkout.Billing$DefaultServiceConnector$1.onServiceDisconnected(SourceFile:1235)
       at android.app.LoadedApk$ServiceDispatcher.doDeath(LoadedApk.java:1340)
       at android.app.LoadedApk$ServiceDispatcher$RunConnection.run(LoadedApk.java:1354)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:158)
       at android.app.ActivityThread.main(ActivityThread.java:7229)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```

fixes #72