### PR TITLE
Refine log level for billing exception

### DIFF
--- a/lib/src/main/java/org/solovyev/android/checkout/Billing.java
+++ b/lib/src/main/java/org/solovyev/android/checkout/Billing.java
@@ -196,7 +196,9 @@ public final class Billing {
             final BillingException be = (BillingException) e;
             switch (be.getResponse()) {
                 case ResponseCodes.OK:
+                    sLogger.d(TAG, message, e);
                 case ResponseCodes.USER_CANCELED:
+                    sLogger.w(TAG, message, e);
                 case ResponseCodes.ACCOUNT_ERROR:
                     sLogger.e(TAG, message, e);
                     break;


### PR DESCRIPTION
When "OK" or "USER_CANCELED" is the response, shouldn't it just log at DEBUG and WARNING level respectively?

eg: Applications that take action on "ERROR" level events end up generating spurious events on a benign issue.